### PR TITLE
fix: correct unit test count in README.md (142 → 126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pnpm test
 pnpm test:integration
 ```
 
-- **Unit tests** — 142 tests with mocked database, IXO, and Matrix services
+- **Unit tests** — 126 tests with mocked database, IXO, and Matrix services
 - **Integration flow tests** — 88 tests that replay recorded USSD sessions against a live server with an ephemeral database
 
 See **[Testing Guide](./docs/TESTING.md)** for full details on running, recording, and adding new flow tests.


### PR DESCRIPTION
Corrects the unit test count in the Testing section of README.md from 142 to 126 to match the actual test suite.

This was missed in PR #10 — the fix was pushed after the PR was merged.

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author